### PR TITLE
feat: SSE streaming with intermediate steps display

### DIFF
--- a/app/api/chat/[chatId]/route.ts
+++ b/app/api/chat/[chatId]/route.ts
@@ -16,37 +16,51 @@ const MOCK_STREAM_EVENTS = [
   { id: "mock-13", data: { type: "end", stage: "end", content: "" } },
 ];
 
-// Receive the user message and return the chatId and sessionId
-export async function POST(request: NextRequest) {
-  const body = await request.json();
+// GET /api/chat/[chatId]?sessionId=xxx
+// SSE stream endpoint: Real-time push of Agent responses
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ chatId: string }> }
+) {
+  const { chatId } = await params;
+  const sessionId = request.nextUrl.searchParams.get('sessionId');
   const useMock = process.env.NODE_ENV === 'development' && process.env.MOCK_API !== 'false';
+
+  console.log(`GET /api/chat/${chatId}?sessionId=${sessionId}`);
 
 if (!useMock) {
     try {
-      console.log('Proxying chat request to backend...');
-      
-      const backendResponse = await fetch('http://10.200.14.82:8996/api/chat', {
-        method: 'POST',
+      const cleanChatId = chatId.replace(/\/$/, '');
+      const backendUrl = `http://10.200.14.82:8996/api/chat/${cleanChatId}?sessionId=${sessionId}`;
+      console.log('Proxying SSE from:', backendUrl);
+
+      const backendResponse = await fetch(backendUrl, {
         headers: { 
-          'Content-Type': 'application/json',
+          'Accept': 'application/json',
           'Cookie': request.headers.get('cookie') || '',
         },
-        body: JSON.stringify(body),
       });
 
-      if (!backendResponse.ok) {
+      if (!backendResponse.ok || !backendResponse.body) {
         const errorText = await backendResponse.text();
-        console.error('Backend error:', backendResponse.status, errorText);
+        console.error('Backend SSE error:', backendResponse.status, errorText);
         return NextResponse.json(
-          { error: `Backend error: ${errorText}` },
+          { error: `Backend error: ${backendResponse.status}` },
           { status: backendResponse.status }
         );
       }
 
-      const data = await backendResponse.json();
-      return NextResponse.json(data);
+      return new Response(backendResponse.body, {
+        status: 200,
+        headers: {
+          'Content-Type': 'text/event-stream',
+          'Cache-Control': 'no-cache',
+          'Connection': 'keep-alive',
+        },
+      });
     } catch (error) {
-      console.error('Backend connection error:', error);
+      console.error('SSE proxy error:', error);
       return NextResponse.json(
         { error: error instanceof Error ? error.message : 'Unknown error' },
         { status: 500 }
@@ -55,13 +69,30 @@ if (!useMock) {
   }
 
   // Mock mode
-  const mockChatId = `mock-chat-${Date.now()}`;
-  const mockSessionId = body?.chatHistoryId || `mock-session-${Date.now()}`;
+  const encoder = new TextEncoder();
 
-  console.log('Mock POST /api/chat → returning chatId:', mockChatId);
+  const stream = new ReadableStream({
+    async start(controller) {
+      for (const event of MOCK_STREAM_EVENTS) {
+        const sseData = `data: ${JSON.stringify(event)}\n\n`;
+        controller.enqueue(encoder.encode(sseData));
 
-  return NextResponse.json({
-    chatId: mockChatId,
-    sessionId: mockSessionId,
+        if (event.data.type === 'reasoning') {
+          await new Promise((resolve) => setTimeout(resolve, 600));  
+        } else if (event.data.type === 'chunk') {
+          await new Promise((resolve) => setTimeout(resolve, 120));  
+        }
+      }
+      controller.close();
+      console.log('Mock SSE stream ended');
+    },
+  });
+
+  return new NextResponse(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      'Connection': 'keep-alive',
+    },
   });
 }

--- a/app/api/get_session/route.ts
+++ b/app/api/get_session/route.ts
@@ -1,9 +1,41 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-export const dynamic = 'force-static';
+export const dynamic = 'force-dynamic';
 
 export async function GET(request: NextRequest) {
-  // Mock session data for development
+  const useMock = process.env.NODE_ENV === 'development' && process.env.MOCK_API !== 'false';
+
+  if (!useMock) {
+    try {
+      const backendResponse = await fetch('http://10.200.14.82:8996/api/c/create_session/', {
+        method: 'GET',
+        headers: {
+          'Cookie': request.headers.get('cookie') || '',
+        },
+      });
+
+      if (!backendResponse.ok) {
+        const errorText = await backendResponse.text();
+        console.error('Backend create_session error:', backendResponse.status, errorText);
+        return NextResponse.json(
+          { error: 'Failed to create session' },
+          { status: backendResponse.status }
+        );
+      }
+
+      const data = await backendResponse.json();
+      console.log('Session created:', data);
+      return NextResponse.json(data);
+    } catch (error) {
+      console.error('Backend connection error:', error);
+      return NextResponse.json(
+        { error: error instanceof Error ? error.message : 'Unknown error' },
+        { status: 500 }
+      );
+    }
+  }
+
+  // Mock mode
   const mockSession = {
     session_id: 'dev-session-' + Date.now(),
     user: {
@@ -17,7 +49,33 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
-  // Handle session creation/update
+  const useMock = process.env.NODE_ENV === 'development' && process.env.MOCK_API !== 'false';
+
+  if (!useMock) {
+    try {
+      const backendResponse = await fetch('http://10.200.14.82:8996/api/c/create_session/', {
+        method: 'POST',
+        headers: {
+          'Cookie': request.headers.get('cookie') || '',
+        },
+      });
+
+      if (!backendResponse.ok) {
+        return NextResponse.json(
+          { error: 'Failed to create session' },
+          { status: backendResponse.status }
+        );
+      }
+
+      return NextResponse.json(await backendResponse.json());
+    } catch (error) {
+      return NextResponse.json(
+        { error: error instanceof Error ? error.message : 'Unknown error' },
+        { status: 500 }
+      );
+    }
+  }
+
   const mockSession = {
     session_id: 'dev-session-' + Date.now(),
     user: {

--- a/components/ChatPage.tsx
+++ b/components/ChatPage.tsx
@@ -44,6 +44,23 @@ const parseMarkdown = (content: string): string => {
 		: cleanedContent;
 };
 
+// The format of each SSE even： { id, data: { type, stage, content } }
+type StreamEvent = {
+  type: "reasoning" | "chunk" | "end";
+  stage: string;
+  content: string;
+};
+
+const parseStreamEvent = (line: string): StreamEvent | null => {
+	if (!line.startsWith("data: ")) return null;
+	try {
+		const jsonStr = line.slice(6); 
+		return JSON.parse(jsonStr) as StreamEvent;
+	} catch {
+		return null;
+	}
+};
+
 const parseThinkingStream = (text: string): { thinking: string; response: string } => {
 	const lines = text.split("\n");
 	const thinkingLines: string[] = [];
@@ -69,8 +86,8 @@ const ensureThinkingBoxStyles = () => {
 	style.innerHTML = `
     .cdku-thinking-box {
       opacity: 0;
-      transform: translateY(6px);
-      transition: opacity 240ms ease-out, transform 240ms ease-out;
+      transform: translateY(4px);
+      transition: opacity 200ms ease-out, transform 200ms ease-out;
     }
     .cdku-thinking-box.tb-entered {
       opacity: 1;
@@ -78,75 +95,59 @@ const ensureThinkingBoxStyles = () => {
     }
     .cdku-thinking-box.tb-dismissing {
       opacity: 0;
-      transform: translateY(-6px);
+      transform: translateY(-4px);
     }
     @keyframes tbCursorPulse {
-      0%, 100% { opacity: 0.2; }
-      50% { opacity: 0.8; }
+      0%, 100% { opacity: 0.3; }
+      50% { opacity: 1; }
     }
     .cdku-thinking-cursor {
       display: inline-block;
-      width: 1px;
-      height: 0.8em;
-      background-color: currentColor;
+      width: 2px;
+      height: 1em;
+      background-color: #6b7280;
       margin-left: 2px;
       vertical-align: text-bottom;
-      animation: tbCursorPulse 1000ms ease-in-out infinite;
+      animation: tbCursorPulse 800ms ease-in-out infinite;
+    }
+    .tb-text {
+      color: #6b7280 !important;
+      font-weight: 500;
     }
   `;
 	document.head.appendChild(style);
 };
 
 const createThinkingBox = (
-	chatLog: HTMLElement,
-): { updateContent: (content: string) => void; dismiss: () => Promise<void> } => {
+	container: HTMLElement,
+): { updateContent: (content: string) => void; dismiss: () => void } => {
 	ensureThinkingBoxStyles();
-	const outerWrapper = document.createElement("div");
-	outerWrapper.className = "flex w-full";
-	outerWrapper.innerHTML = `
-    <div class="flex flex-col items-start w-full sm:max-w-[85%]">
-      <div class="cdku-thinking-box flex flex-col lg:flex-row gap-3 px-4 py-2 w-full">
-        <div class="flex-shrink-0">
-          <div class="w-8 h-8 rounded-full bg-transparent flex items-center justify-center">
-            <img src="/logos/new_logo.svg" class="p-1.5 opacity-60" alt="ChatDKU"/>
-          </div>
-        </div>
-        <div class="flex-1 min-w-0">
-          <div class="tb-scroll h-[120px] overflow-hidden rounded-xl px-3 py-2.5 select-none" style="background:color-mix(in srgb,var(--muted) 20%,transparent);border:1px solid color-mix(in srgb,var(--border) 30%,transparent)">
-            <p class="tb-text font-mono text-[11px] leading-relaxed whitespace-pre-wrap break-words m-0 pointer-events-none" style="color:color-mix(in srgb,var(--muted-foreground) 55%,transparent)"><span class="cdku-thinking-cursor"></span></p>
-          </div>
-        </div>
-      </div>
-    </div>
-  `;
-	chatLog.appendChild(outerWrapper);
-	chatLog.scrollTo(0, chatLog.scrollHeight);
-
-	const thinkingBox = outerWrapper.querySelector(".cdku-thinking-box") as HTMLElement;
-	const textEl = outerWrapper.querySelector(".tb-text") as HTMLElement;
-	const scrollEl = outerWrapper.querySelector(".tb-scroll") as HTMLElement;
+	
+	const thinkingEl = document.createElement("p");
+	thinkingEl.className = "cdku-thinking-box tb-text font-mono text-[12px] leading-relaxed whitespace-pre-wrap break-words m-0";
+	thinkingEl.style.cssText = "color:#6b7280;font-weight:500;";
+	thinkingEl.innerHTML = '<span class="cdku-thinking-cursor"></span>';
+	
+	container.appendChild(thinkingEl);
 
 	requestAnimationFrame(() => {
 		requestAnimationFrame(() => {
-			thinkingBox.classList.add("tb-entered");
+			thinkingEl.classList.add("tb-entered");
 		});
 	});
 
 	return {
 		updateContent: (content: string) => {
-			textEl.innerHTML = "";
-			textEl.appendChild(document.createTextNode(content));
+			thinkingEl.innerHTML = "";
+			thinkingEl.appendChild(document.createTextNode(content));
 			const cursor = document.createElement("span");
 			cursor.className = "cdku-thinking-cursor";
-			textEl.appendChild(cursor);
-			scrollEl.scrollTop = scrollEl.scrollHeight;
-			chatLog.scrollTo(0, chatLog.scrollHeight);
+			thinkingEl.appendChild(cursor);
 		},
-		dismiss: async () => {
-			thinkingBox.classList.remove("tb-entered");
-			thinkingBox.classList.add("tb-dismissing");
-			await new Promise((r) => setTimeout(r, 260));
-			outerWrapper.remove();
+		dismiss: () => {
+			thinkingEl.classList.remove("tb-entered");
+			thinkingEl.classList.add("tb-dismissing");
+			setTimeout(() => thinkingEl.remove(), 260);
 		},
 	};
 };
@@ -215,6 +216,128 @@ const getSearchLoaderHTML = (): string => {
       </div>
     </div>
   `;
+};
+
+
+const streamSSEFromReader = async (
+	response: Response,
+	streamContainer: HTMLElement,
+	chatLog: HTMLElement,
+): Promise<string> => {
+	if (!response.body) {
+		throw new Error("No response body");
+	}
+
+	const reader = response.body.getReader();
+	const decoder = new TextDecoder();
+	let buffer = "";
+	let fullAnswer = "";
+	let thinkingBox: ReturnType<typeof createThinkingBox> | null = null;
+
+	const contentDiv = document.createElement("div");
+	contentDiv.className =
+		"text-foreground break-words overflow-wrap-anywhere markdown-content text-[0.9375rem]";
+	streamContainer.innerHTML = "";
+	streamContainer.appendChild(contentDiv);
+
+	try {
+		while (true) {
+			const { done, value } = await reader.read();
+			if (done) break;
+
+			buffer += decoder.decode(value, { stream: true });
+
+
+			const parts = buffer.split("\n\n");
+			buffer = parts.pop() || "";
+
+			for (const part of parts) {
+				if (!part.trim()) continue;
+				console.log('SSE part:', JSON.stringify(part));
+
+
+				const lines = part.split("\n");
+				let dataLine = "";
+				for (const line of lines) {
+					if (line.startsWith("data: ")) {
+						dataLine = line.slice(6); 
+						break;
+					}
+				}
+				if (!dataLine) continue;
+				console.log('Parsed data:', dataLine);
+
+				let event: StreamEvent | null = null;
+				try {
+					event = JSON.parse(dataLine) as StreamEvent;
+				} catch {
+					continue;
+				}
+
+				const eventData = (event as any).data || event;
+				const { type, stage, content } = eventData;
+
+				if (type === "reasoning") {
+					if (!thinkingBox) {
+						thinkingBox = createThinkingBox(streamContainer);
+					}
+					const displayText = content
+						? `[${stage}] ${content}`
+						: `[${stage}]`;
+					thinkingBox.updateContent(displayText);
+				} else if (type === "chunk") {
+					if (thinkingBox) {
+						const box = thinkingBox;
+						thinkingBox = null;
+						void box.dismiss();
+					}
+					fullAnswer += content;
+					const cleaned = fullAnswer.replace(/<think>[\s\S]*?<\/think>/gi, "");
+					contentDiv.innerHTML = parseMarkdown(cleaned);
+				} else if (type === "end") {
+					if (thinkingBox) {
+						const box = thinkingBox;
+						thinkingBox = null;
+						void box.dismiss();
+					}
+				}
+			}
+
+			chatLog.scrollTo(0, chatLog.scrollHeight);
+		}
+
+		if (buffer.trim()) {
+			const lines = buffer.split("\n");
+			for (const line of lines) {
+				if (line.startsWith("data: ")) {
+					try {
+						const event = JSON.parse(line.slice(6)) as StreamEvent;
+						if (event.type === "chunk") {
+							fullAnswer += event.content;
+						}
+					} catch { /* ignore */ }
+				}
+			}
+			const cleaned = fullAnswer.replace(/<think>[\s\S]*?<\/think>/gi, "");
+			contentDiv.innerHTML = parseMarkdown(cleaned);
+		}
+
+		if (thinkingBox) {
+			const box = thinkingBox;
+			thinkingBox = null;
+			void box.dismiss();
+		}
+
+		return fullAnswer;
+	} catch (error) {
+		console.warn("SSE stream reading failed:", error);
+		if (thinkingBox) {
+			const box = thinkingBox;
+			thinkingBox = null;
+			void box.dismiss();
+		}
+		return fullAnswer || "Error: Failed to read response";
+	}
 };
 
 const streamFromReader = async (
@@ -478,7 +601,7 @@ export default function ChatPage({ isDev = false }: ChatPageProps) {
 								? ""
 								: '<div class="flex-shrink-0"><div class="w-8 h-8 rounded-full bg-transparent flex items-center justify-center"><img src="/logos/new_logo.svg" class="block dark:hidden p-1.5" alt="Logo"/><img src="/logos/new_logo.svg" class="hidden dark:block p-1.5" alt="Logo"/></div></div>'
 						}
-            <div class="${isUser ? "text-right" : "text-left"} overflow-hidden">
+            <div class="text-left overflow-hidden">
               <div class="text-foreground break-words overflow-wrap-anywhere markdown-content ${!isUser ? "text-[0.9375rem]" : ""}">${sanitizedContent}</div>
             </div>
           </div>
@@ -492,20 +615,14 @@ export default function ChatPage({ isDev = false }: ChatPageProps) {
         <div class="flex flex-col items-start w-full sm:max-w-[85%]">
           <div class="flex flex-col lg:flex-row gap-3 px-4 py-2 ${className} rounded-3xl w-full overflow-hidden">
             <div class="flex-shrink-0"><div class="w-8 h-8 rounded-full bg-transparent flex items-center justify-center"><img src="/logos/new_logo.svg" class="block dark:hidden p-1.5" alt="Logo"/><img src="/logos/new_logo.svg" class="hidden dark:block p-1.5" alt="Logo"/></div></div>
-            <div class="text-left overflow-hidden" id="stream-container">
+            <div class="text-left overflow-hidden" id="stream-container-${Date.now()}">
+              <!-- SSE stream content will be updated in real-time here -->
             </div>
           </div>
         </div>
       `;
 				chatLog?.appendChild(messageElement);
 				chatLog?.scrollTo(0, chatLog.scrollHeight);
-
-				const streamContainer = messageElement.querySelector(
-					"#stream-container",
-				) as HTMLElement;
-				if (streamContainer) {
-					streamText(content, streamContainer, isDev ? 90 : 60);
-				}
 
 				return messageElement.querySelector(".flex.flex-col");
 			}
@@ -716,37 +833,49 @@ export default function ChatPage({ isDev = false }: ChatPageProps) {
 									const rawBotMessage = addAssistantRawHtml(getSearchLoaderHTML(), "text-sm");
 									botMessage = rawBotMessage instanceof HTMLElement ? rawBotMessage : null;
 
-									const fetchChat = async (sessionId: string) => {
-										if (value.trim().toLowerCase() === "test") {
-											return fetch("/mdtest.md");
-										}
-										const url = isDev
-											? apiEndpoint
-											: "https://chatdku.dukekunshan.edu.cn/api/chat";
-										return fetch(url, {
-											method: "POST",
-											headers: { "Content-Type": "application/json" },
-											body: JSON.stringify({
-												messages: [{ role: "user", content: finalValue }],
-												chatHistoryId: sessionId,
-												mode: thinkingMode ? "agent" : "",
-												searchMode: searchMode,
-											}),
-										});
+
+									// 1. POST /api/chat → chatId
+									const postUrl = isDev
+										? apiEndpoint || "/api/chat"
+										: "/api/chat";
+
+									const postBody: Record<string, unknown> = {
+										messages: [{ role: "user", content: finalValue }],
+										chatHistoryId: activeSessionId,
 									};
+									if (thinkingMode) postBody.mode = "agent";
+									if (searchMode) postBody.searchMode = searchMode;
 
-									let response = await fetchChat(activeSessionId);
+									console.log("Step 1: POST", postUrl, postBody);
 
-									if (!response.ok) {
-										const newSession = await getNewSession();
-										if (newSession) {
-											setCurrentSessionId(newSession);
-											setChatHistoryId(newSession);
-											response = await fetchChat(newSession);
-										}
+									const postResponse = await fetch(postUrl, {
+										method: "POST",
+										headers: { "Content-Type": "application/json" },
+										body: JSON.stringify(postBody),
+									});
+
+									if (!postResponse.ok) {
+										throw new Error(`POST failed: ${postResponse.status} ${postResponse.statusText}`);
 									}
 
-									if (!response.ok) throw new Error("Failed to fetch response");
+									const { chatId } = await postResponse.json();
+									console.log("Got chatId:", chatId);
+
+									if (!chatId) {
+										throw new Error("No chatId returned from POST /api/chat");
+									}
+
+									// 2. GET /api/chat/{chatId}?sessionId=xxx → SSE
+									const sseUrl = `/api/chat/${chatId}?sessionId=${encodeURIComponent(activeSessionId)}`;
+									console.log("Step 2: GET (SSE)", sseUrl);
+
+									const sseResponse = await fetch(sseUrl, {
+										headers: { "Accept": "text/event-stream" },
+									});
+
+									if (!sseResponse.ok) {
+										throw new Error(`SSE GET failed: ${sseResponse.status}`);
+									}
 
 									if (botMessage) {
 										botMessage.remove();
@@ -759,59 +888,18 @@ export default function ChatPage({ isDev = false }: ChatPageProps) {
 										true,
 									);
 
-									const streamContainer =
-										messageDiv?.querySelector("#stream-container");
-									if (!streamContainer)
+									const streamContainer = messageDiv?.querySelector("[id^='stream-container-']") as HTMLElement;
+									if (!streamContainer) {
 										throw new Error("Failed to create stream container");
+									}
 
-									const thinkingChatLog = document.getElementById("chat-log");
-									let thinkingBox: ReturnType<typeof createThinkingBox> | null = null;
+									const chatLog = document.getElementById("chat-log")!;
 
-									const streamResult = await streamFromReader(
-										response,
-										streamContainer as HTMLElement,
-										{
-											onThinkingContent: (content) => {
-												if (!thinkingBox && thinkingChatLog) {
-													thinkingBox = createThinkingBox(thinkingChatLog);
-												}
-												thinkingBox?.updateContent(content);
-											},
-											onResponseStart: () => {
-												if (thinkingBox) {
-													const box = thinkingBox;
-													thinkingBox = null;
-													void box.dismiss();
-												}
-											},
-										},
+									const data = await streamSSEFromReader(
+										sseResponse,
+										streamContainer,
+										chatLog,
 									);
-
-									const pendingBox = thinkingBox;
-									if (pendingBox) {
-										thinkingBox = null;
-										await pendingBox.dismiss();
-									}
-
-									let data: string;
-									if (streamResult.success) {
-										data = streamResult.text;
-									} else {
-										data = streamResult.text;
-										if (!data) {
-											try {
-												data = await response.text();
-											} catch {
-												data = "Error: Failed to read response";
-											}
-										}
-										(streamContainer as HTMLElement).innerHTML = "";
-										await streamText(
-											data,
-											streamContainer as HTMLElement,
-											isDev ? 90 : 60,
-										);
-									}
 
 									if (messageDiv) {
 										const feedbackDiv = document.createElement("div");
@@ -895,6 +983,7 @@ export default function ChatPage({ isDev = false }: ChatPageProps) {
 										messageDiv.appendChild(feedbackDiv);
 									}
 								} catch (error) {
+									console.error("Chat error:", error);
 									if (botMessage) botMessage.remove();
 									addMessageToChat(
 										"assistant",


### PR DESCRIPTION
Implemented SSE streaming response and intermediate steps display:

- Added GET /api/chat/[chatId] SSE proxy endpoint
- Updated POST /api/chat to return chatId format
- Proxied /api/get_session to real backend for UUID retrieval
- Parsed SSE JSON stream, distinguishing reasoning / chunk / end types
- Displayed intermediate reasoning steps as gray text next to avatar, auto-dismiss when answer chunks arrive

Also frontend can now connect directly to the backend for local testing by setting MOCK_API=false