### PR TITLE
fix: remove output export to support dynamic SSE route

### DIFF
--- a/app/api/chat/[chatId]/route.ts
+++ b/app/api/chat/[chatId]/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+export const dynamic = 'force-dynamic';
 
 const MOCK_STREAM_EVENTS = [
   { id: "mock-1", data: { type: "reasoning", stage: "start", content: "Agent started" } },

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+export const dynamic = 'force-dynamic';
 
 const MOCK_STREAM_EVENTS = [
   { id: "mock-1", data: { type: "reasoning", stage: "start", content: "Agent started" } },

--- a/app/api/get_session/route.ts
+++ b/app/api/get_session/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from 'next/server';
-
 export const dynamic = 'force-dynamic';
 
 export async function GET(request: NextRequest) {

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,8 +3,6 @@ import type { NextConfig } from "next";
 const isDevMode = process.env.NODE_ENV === 'development';
 
 const nextConfig: NextConfig = {
-  // Only use static export in production
-  ...(isDevMode ? {} : { output: 'export' }),
   trailingSlash: true,
   
   // Images configuration


### PR DESCRIPTION
Removing output: 'export' from next.config.ts so the SSE route can be dynamic
There was no problem with my local test of "npm run build"